### PR TITLE
Improve DbPool type.

### DIFF
--- a/src/Traction/Sql.hs
+++ b/src/Traction/Sql.hs
@@ -11,7 +11,9 @@ module Traction.Sql (
   , execute
   , execute_
   , value
+  , valueWith
   , values
+  , valuesWith
   ) where
 
 import           Database.PostgreSQL.Simple.SqlQQ (sql)
@@ -80,6 +82,14 @@ value :: Functor f => f (Only a) -> f a
 value =
   fmap fromOnly
 
+valueWith :: Functor f => (a -> b) -> f (Only a) -> f b
+valueWith f =
+  fmap (f . fromOnly)
+
 values :: (Functor f, Functor g) => g (f (Only a)) -> g (f a)
 values =
   (fmap . fmap) fromOnly
+
+valuesWith :: (Functor f, Functor g) => (a -> b) -> g (f (Only a)) -> g (f b)
+valuesWith f =
+  (fmap . fmap) (f . fromOnly)

--- a/traction.cabal
+++ b/traction.cabal
@@ -21,6 +21,7 @@ library
     , postgresql-simple == 0.5.*
     , resource-pool == 0.2.*
     , text == 1.2.*
+    , time >= 1.5 && < 1.10
     , transformers == 0.5.*
 
   ghc-options:


### PR DESCRIPTION
Allow for implementing external rollback without
changing runDb.

Remove need for testDb.

Remove double rollback from runDb.

/cc @novemberkilo This is to clean-up some minor issues and make it possible for me to write some higher-level tests.