### PR TITLE
Tracing and EXPLAIN

### DIFF
--- a/src/Traction/Sql.hs
+++ b/src/Traction/Sql.hs
@@ -66,32 +66,38 @@ mandatory_ q =
   liftDb . definitely q $ unique_ q
 
 unique :: (MonadDb m, ToRow a, FromRow b) => Postgresql.Query -> a -> m (Maybe b)
-unique q parameters =
+unique q parameters = do
+  trace q
   liftDb . possibly q . withConnection q $ \c ->
     Postgresql.query c q parameters
 
 unique_ :: (MonadDb m, FromRow a) => Postgresql.Query -> m (Maybe a)
-unique_ q =
+unique_ q = do
+  trace q
   liftDb . possibly q . withConnection q $ \c ->
     Postgresql.query_ c q
 
 query :: (MonadDb m, ToRow a, FromRow  b) => Postgresql.Query -> a -> m [b]
-query q parameters =
+query q parameters = do
+  trace q
   liftDb . withConnection q $ \c ->
     Postgresql.query c q parameters
 
 query_ :: (MonadDb m, FromRow a) => Postgresql.Query -> m [a]
-query_ q =
+query_ q = do
+  trace q
   liftDb . withConnection q $ \c ->
     Postgresql.query_ c q
 
 execute :: (MonadDb m, ToRow a) => Postgresql.Query -> a -> m Int64
-execute q parameters =
+execute q parameters = do
+  trace q
   liftDb . withConnection q $ \c ->
     Postgresql.execute c q parameters
 
 execute_ :: MonadDb m => Postgresql.Query -> m Int64
-execute_ q =
+execute_ q = do
+  trace q
   liftDb . withConnection q $ \c ->
     Postgresql.execute_  c q
 

--- a/src/Traction/Sql.hs
+++ b/src/Traction/Sql.hs
@@ -16,6 +16,7 @@ module Traction.Sql (
   , execute
   , execute_
   , explain
+  , explain_
   , value
   , valueWith
   , values
@@ -95,7 +96,10 @@ execute_ q =
     Postgresql.execute_  c q
 
 explain :: (MonadDb m, ToRow a) => Postgresql.Query -> a -> m Text
-explain q a = Text.unlines . fmap fromOnly <$> query q a
+explain q a = Text.unlines . value <$> query q a
+
+explain_ :: MonadDb m => Postgresql.Query -> m Text
+explain_ q = Text.unlines . value <$> query_ q
 
 possibly :: Postgresql.Query -> Db [a] -> Db (Maybe a)
 possibly q db =

--- a/src/Traction/Sql.hs
+++ b/src/Traction/Sql.hs
@@ -15,6 +15,7 @@ module Traction.Sql (
   , query_
   , execute
   , execute_
+  , explain
   , value
   , valueWith
   , values
@@ -92,6 +93,9 @@ execute_ :: MonadDb m => Postgresql.Query -> m Int64
 execute_ q =
   liftDb . withConnection q $ \c ->
     Postgresql.execute_  c q
+
+explain :: (MonadDb m, ToRow a) => Postgresql.Query -> a -> m Text
+explain q a = Text.unlines . fmap fromOnly <$> query q a
 
 possibly :: Postgresql.Query -> Db [a] -> Db (Maybe a)
 possibly q db =

--- a/test/Test/Traction.hs
+++ b/test/Test/Traction.hs
@@ -8,6 +8,7 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Morph (hoist, lift)
 
 import           Data.Text (Text)
+import qualified Data.Text as Text
 
 import           Traction.Prelude
 import           Traction.Control
@@ -19,6 +20,18 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 
 import           System.IO (IO)
+
+prop_explain :: Property
+prop_explain =
+  property $ do
+    organisation <- forAll genOrganisation
+    r <- db $
+      explain [sql|
+        EXPLAIN INSERT INTO organisation (name)
+            VALUES (?)
+          RETURNING id
+      |] (Only organisation)
+    assert (Text.isPrefixOf "Insert on organisation" r)
 
 prop_insert_unique :: Property
 prop_insert_unique =

--- a/traction.cabal
+++ b/traction.cabal
@@ -24,14 +24,14 @@ library
     , containers >= 0.5.8 && < 0.7
     , exceptions == 0.10.*
     , mmorph == 1.*
-    , postgresql-simple == 0.5.*
+    , postgresql-simple >= 0.5 && < 0.7
     , resource-pool == 0.2.*
     , syb >= 0.4 && < 0.8
     , template-haskell
     , text == 1.2.*
     , time >= 1.5 && < 1.10
     , transformers == 0.5.*
-    , transformers-either == 0.0.*
+    , transformers-either >= 0 && < 0.2
 
   ghc-options:
     -Wall
@@ -53,9 +53,9 @@ test-suite test
   hs-source-dirs: test
   build-depends:
       base >= 3 && < 5
-    , hedgehog == 0.5.*
+    , hedgehog >= 0.5 && < 1.1
     , mmorph == 1.*
-    , postgresql-simple == 0.5.*
+    , postgresql-simple >= 0.5 && < 0.7
     , resource-pool == 0.2.*
     , text == 1.2.*
     , traction


### PR DESCRIPTION
How does this look?

At the moment if you want to trace the query and its parameters, you `withTracing` your query, or set tracing on at the top level - and then manually trace your parameters after the query with `trace`. I don't like that it's semi-automatic for queries but manual for the parameters.

I can trace the parameters automatically if I demand `Show` of them in type signatures like `execute`. Do you agree that would be unreasonable? It's possible we could do something with constraintkinds to get it working, but that seems to violate the simplicity philosophy I'm feeling in this library.

I could also just duplicate
`execute, execute_ ==> execute, execute_, executeTrace, executeTrace_` but that seems a bit much.

Thoughts?