### PR TITLE
Add executeMany to Traction.Sql for bulk operations

### DIFF
--- a/src/Traction/Sql.hs
+++ b/src/Traction/Sql.hs
@@ -15,6 +15,7 @@ module Traction.Sql (
   , query_
   , execute
   , execute_
+  , executeMany
   , explain
   , explain_
   , value
@@ -100,6 +101,12 @@ execute_ q = do
   trace q
   liftDb . withConnection q $ \c ->
     Postgresql.execute_  c q
+
+executeMany :: (MonadDb m, ToRow a) => Postgresql.Query -> [a] -> m Int64
+executeMany q parameters = do
+  trace q
+  liftDb . withConnection q $ \c ->
+    Postgresql.executeMany c q parameters
 
 explain :: (MonadDb m, ToRow a) => Postgresql.Query -> a -> m Text
 explain q a = Text.unlines . value <$> query q a


### PR DESCRIPTION
adding in support for the `executeMany` function that is supplied by postgers-simple. 